### PR TITLE
add link to bash script for setting up a miner

### DIFF
--- a/testnet_resources.md
+++ b/testnet_resources.md
@@ -11,3 +11,4 @@ A running list of community-generated tools and resources for navigating the Sta
 - Test STX Transactions: https://speed-spend.netlify.app/
 - Stacks Miner Dashboard Mock Up: https://discordapp.com/channels/621759717756370964/691807526118883418/705815477150023781
 - Bash script to setup a miner on Ubuntu Server: https://github.com/AbsorbingChaos/bks-setup-miner/
+    - Youtube video showing its use and additional information: https://www.youtube.com/watch?v=rOs8ZqCt_xM

--- a/testnet_resources.md
+++ b/testnet_resources.md
@@ -6,9 +6,9 @@ A running list of community-generated tools and resources for navigating the Sta
 - Multiplatform Stacks Transaction Library: https://github.com/openintents/stacks-transactions-kotlin
 - Run Stacks 2.0 Using Docker: https://github.com/viraja1/stacks-blockchain-docker
 - Linux Instance - Testnet node configure as systemctl daemon: https://discordapp.com/channels/621759717756370964/691807526118883418/703047755777441893
-- Installing a Neon Node (Live demo in Spanish: https://youtu.be/k5XJNrE_y0Y
+- Installing a Neon Node (Live demo in Spanish): https://youtu.be/k5XJNrE_y0Y
 - Raspberry Pi image for running a Stacks Node: https://agitated-pare-dfa673.netlify.app/
 - Test STX Transactions: https://speed-spend.netlify.app/
 - Stacks Miner Dashboard Mock Up: https://discordapp.com/channels/621759717756370964/691807526118883418/705815477150023781
-- Bash script to setup a miner on Ubuntu Server: https://github.com/AbsorbingChaos/bks-setup-miner/
+- Bash script to setup an Argon miner on Ubuntu Server: https://github.com/AbsorbingChaos/bks-setup-miner/
     - Youtube video showing its use and additional information: https://www.youtube.com/watch?v=rOs8ZqCt_xM

--- a/testnet_resources.md
+++ b/testnet_resources.md
@@ -10,3 +10,4 @@ A running list of community-generated tools and resources for navigating the Sta
 - Raspberry Pi image for running a Stacks Node: https://agitated-pare-dfa673.netlify.app/
 - Test STX Transactions: https://speed-spend.netlify.app/
 - Stacks Miner Dashboard Mock Up: https://discordapp.com/channels/621759717756370964/691807526118883418/705815477150023781
+- Bash script to setup a miner on Ubuntu Server: https://github.com/AbsorbingChaos/bks-setup-miner/


### PR DESCRIPTION
This PR adds a link to my repository for a one-liner bash script that sets up and/or updates a miner on Ubuntu Server. It should work with Ubuntu Desktop as well, and simplifies the process to avoid having people type in more than one command.